### PR TITLE
fix: require semantic-release@15.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "all": true
   },
   "peerDependencies": {
-    "semantic-release": ">=15.8.0 <16.0.0"
+    "semantic-release": ">=15.9.0 <16.0.0"
   },
   "prettier": {
     "printWidth": 120,


### PR DESCRIPTION
BREAKING CHANGE: require `semantic-release` >= `15.9.0`