### PR TITLE
ci(renovate): fixed the reference to the org-level config

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "renovate": {
     "extends": [
-      "github>semantic-release/.github"
+      "github>semantic-release/.github:renovate-config"
     ]
   }
 }


### PR DESCRIPTION
to better align with the recommendation for org-level presets: https://docs.renovatebot.com/config-presets/#grouporganization-level-presets