### PR TITLE
docs: update semantic-release configuration documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ npm install --save-dev semantic-release @semantic-release/gitlab-config
 
 ## Usage
 
-The shareable config can be configured in the [**semantic-release** configuration file](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#configuration):
+The shareable config can be configured in the [**semantic-release** configuration file](https://semantic-release.org/usage/configuration#configuration-file):
 
 ```json
 {


### PR DESCRIPTION
This pull request updates the documentation to reference the new official location for the semantic-release configuration file documentation.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L25-R25): Updated the link to the semantic-release configuration file documentation to use the new official site instead of the old GitHub URL.